### PR TITLE
聖杯レイアウトホーム画面？

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+deno.lock
+
+.vscode

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,9 @@
+{
+    "imports": {
+      "http/": "https://deno.land/std@0.194.0/http/",
+      "testing/": "https://deno.land/std@0.193.0/testing/"
+    },
+    "tasks": {
+      "start": "deno run --watch --allow-net --allow-read server.js"
+    }
+  }

--- a/page/index.html
+++ b/page/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="stylesheet" href="styles.css">
+	<title>Jig.jpインターンへようこそ</title>
+</head>
+<body>
+  <!-- サーバーから返ってきた文字を表示する場所 -->
+	<h1 id="home-page-title"></h1>
+	<div class="holy-grail-flexbox">
+		<header class="header">Header</header>
+		<main class="main-content">Main content</main>
+		<section class="left-sidebar">Left sidebar</section>
+		<aside class="right-sidebar">Right sidebar</aside>
+		<footer class="footer">Footer</footer>
+	</div>
+
+  <script type="module" src="./page.js"></script>
+</body>
+</html>

--- a/page/page.js
+++ b/page/page.js
@@ -1,0 +1,7 @@
+/**
+ * ロードが終わったら 「GET /home-page」でサーバーにアクセスする
+ */
+window.onload = async () => {
+    const response = await fetch('/home-page');
+    document.querySelector('#home-page-title').innerText = await response.text();
+}

--- a/page/styles.css
+++ b/page/styles.css
@@ -1,0 +1,54 @@
+body {
+    text-align: center;
+    background: rgb(143, 223, 255);
+}
+
+/* set correct box model */
+* {
+    box-sizing:border-box;
+}
+
+/* flexbox container */
+.holy-grail-flexbox {
+    display:flex;
+    flex-wrap:wrap;
+}
+
+/* columns (mobile) */
+.holy-grail-flexbox > * {
+    width:100%;
+    padding:1rem;
+}
+
+/* background colors */
+.holy-grail-flexbox > .header {background:#f97171}
+.holy-grail-flexbox > .main-content {background:#fff}
+.holy-grail-flexbox > .left-sidebar {background:#f5d55f}
+.holy-grail-flexbox > .right-sidebar {background:#c5ed77}
+.holy-grail-flexbox > .footer {background:#72c2f1}
+
+/* tablet breakpoint */
+@media (min-width:768px) {
+    .holy-grail-flexbox > .left-sidebar,
+    .holy-grail-flexbox > .right-sidebar {
+        width:50%;
+    }
+}
+
+/* desktop breakpoint */
+@media (min-width:1024px) {
+    .holy-grail-flexbox > .header {
+        order:-2; /* header first */
+    }
+    .holy-grail-flexbox > .left-sidebar {
+        /* left sidebar second (first in second row) */
+        order:-1; 
+    }
+    .holy-grail-flexbox > .main-content {
+        width:50%;
+    }
+    .holy-grail-flexbox > .left-sidebar,
+    .holy-grail-flexbox > .right-sidebar {
+        width:25%;
+    }
+}

--- a/page/styles.css
+++ b/page/styles.css
@@ -15,7 +15,28 @@ body {
 }
 
 /* columns (mobile) */
-.holy-grail-flexbox > * {
+.holy-grail-flexbox > .header {
+    order: -2;
+    width:100%;
+    padding:1rem;
+}
+.holy-grail-flexbox > .left-sidebar {
+    order: -1;
+    width:100%;
+    padding:1rem;
+}
+.holy-grail-flexbox > .main-content {
+    order: 1;
+    width:100%;
+    padding:1rem;
+}
+.holy-grail-flexbox > .right-sidebar {
+    order: 2;
+    width:100%;
+    padding:1rem;
+}
+.holy-grail-flexbox > .footer {
+    order: 3;
     width:100%;
     padding:1rem;
 }
@@ -29,9 +50,30 @@ body {
 
 /* tablet breakpoint */
 @media (min-width:768px) {
-    .holy-grail-flexbox > .left-sidebar,
+    .holy-grail-flexbox > .header {
+        order: -2;
+        width:100%;
+        padding:1rem;
+    }
+    .holy-grail-flexbox > .left-sidebar {
+        order: -1;
+        width:100%;
+        padding:1rem;
+    }
+    .holy-grail-flexbox > .main-content {
+        order: 1;
+        width:100%;
+        padding:1rem;
+    }
     .holy-grail-flexbox > .right-sidebar {
-        width:50%;
+        order: 2;
+        width:100%;
+        padding:1rem;
+    }
+    .holy-grail-flexbox > .footer {
+        order: 3;
+        width:100%;
+        padding:1rem;
     }
 }
 
@@ -45,6 +87,7 @@ body {
         order:-1; 
     }
     .holy-grail-flexbox > .main-content {
+        
         width:50%;
     }
     .holy-grail-flexbox > .left-sidebar,

--- a/server.js
+++ b/server.js
@@ -1,0 +1,25 @@
+// https://deno.land/std@0.194.0/http/server.ts?s=serve
+import { serve } from 'http/server.ts'
+// https://deno.land/std@0.194.0/http/file_server.ts?s=serveDir
+import { serveDir } from 'http/file_server.ts'
+
+/**
+ * APIリクエストを処理する
+ */
+serve((req) => {
+  // URLのパスを取得
+  const pathname = new URL(req.url).pathname;
+  console.log(pathname);
+  // パスが'/welcome-message'だったら「'jigインターンへようこそ！'」の文字を返す
+  if (req.method === 'GET' && pathname === '/home-page') {
+    return new Response('Hello World!');
+  }
+
+  // publicフォルダ内にあるファイルを返す
+  return serveDir(req, {
+    fsRoot: './page',
+    urlRoot: '',
+    showDirListing: true,
+    enableCors: true,
+  });
+});


### PR DESCRIPTION
概要
聖杯レイアウトホーム画面

Mobile, Tabletの画面はGitHubのようにHeaderが１，Leftが２でMainが3のようにしている。
Desktopの画面は定番の聖杯レイアウトです。

関連
テスト方法
deno task start -> http://localhost:8000/

レビュアーチェックリスト
元々のファイルと衝突があるかどうか

 関連にIssueもしくはタスクのリンクがあること