### PR TITLE
🎨 refactor：アイコンに使える画像の拡張子を制限&デフォルトアイコンが正常に表示されるように修正

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -59,7 +59,7 @@
             type="file"
             id="iconInput"
             onchange="previewIcon(this)"
-            accept=".jpg, .jpeg, .png, .HEIC"
+            accept=".jpg, .jpeg, .png"
           />
         </div>
         <div class="inputContainer">

--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,12 @@
           document.getElementById("iconImg").src = localStorage.getItem("icon");
         }
 
+        if (localStorage.getItem("icon")) {
+          document.getElementById("iconImg").src = localStorage.getItem("icon");
+        } else {
+          document.getElementById("iconImg").src = "img/noImage.jpg";
+        }
+
         signUpButton.addEventListener("click", function (event) {
           localStorage.setItem("name", nameInput.value);
           localStorage.setItem("active", activeInput.value);
@@ -49,7 +55,12 @@
         </div>
         <div id="icon">
           <img src="img/noImage.jpg" alt="icon image" id="iconImg" />
-          <input type="file" id="iconInput" onchange="previewIcon(this)" />
+          <input
+            type="file"
+            id="iconInput"
+            onchange="previewIcon(this)"
+            accept=".jpg, .jpeg, .png, .HEIC"
+          />
         </div>
         <div class="inputContainer">
           <label>最近の出来事</label>

--- a/public/main.html
+++ b/public/main.html
@@ -12,7 +12,12 @@
         const active = document.getElementById("active");
         active.innerHTML = localStorage.getItem("active");
         const editButton = document.getElementById("editButton");
-        document.getElementById("iconImg").src = localStorage.getItem("icon");
+
+        if (localStorage.getItem("icon")) {
+          document.getElementById("iconImg").src = localStorage.getItem("icon")
+        } else {
+          document.getElementById("iconImg").src = "img/noImage.jpg";
+        }
 
         editButton.addEventListener("click", function (event) {
           localStorage.setItem("active", "");
@@ -58,16 +63,10 @@
     </script>
   </head>
   <body>
-    <!-- <div id="readQrContainer">
-      <a href="./match.html" id="qrLink">
-        <img src="./img/readQR.png" alt="QRコード読み取り" id="readQrImg" />
-      </a>
-    </div> -->
     <header id="header"></header>
     <div id="container">
       <div id="QR">
         <div id="QRCode"></div>
-        <!-- <img src="./img/QR.jpg" alt="QRコード" id="qrImg" /> -->
         <div>
           <div class="col-sm-6">
             <div>


### PR DESCRIPTION
## 概要

- アイコンに使える画像の拡張子を制限(jpg,jepg,png,HEIC)
- デフォルトアイコンが正常に表示されるように修正

## テスト方法

deno deployから実機で確認してください

## レビュアーチェックリスト

- [ ] アイコン画像の拡張子が制限できているか
- [ ] デフォルトアイコンが正常に表示されているか

