### PR TITLE
起動パラメータでポート番号設定対応、IPv6対応

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ const userDataMap = new Map(); // 名前と出来事を記録するマップ
 * APIリクエストを処理する
 */
 Deno.serve({
-  port: Deno.args[0] || 8080,
+  port: Deno.args[0] ?? 8080,
   hostname: "[::]",
 
   handler: async (req) => {

--- a/server.js
+++ b/server.js
@@ -12,7 +12,8 @@ const userDataMap = new Map(); // 名前と出来事を記録するマップ
 * APIリクエストを処理する
 */
 Deno.serve({
-  port: 8080,
+  port: Deno.args[0] || 8080,
+  hostname: "[::]",
 
   handler: async (req) => {
     if (req.headers.get("upgrade") === "websocket") {


### PR DESCRIPTION
## 概要

VPS上で起動できるようにするため、起動ポートを設定したい

## 関連

https://github.com/jigintern/real-2024-b/issues/59

## テスト方法

- 起動パラメータにポート番号を設定して、そのポート番号で起動する
- 起動パラメータがなければ、デフォルトの8080ポートで起動する

## レビュアーチェックリスト

- [ ] 関連にIssueもしくはタスクのリンクがあること
