### PR TITLE
起動オプションを追加

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -4,6 +4,6 @@
     "testing/": "https://deno.land/std@0.193.0/testing/"
   },
   "tasks": {
-    "start": "deno run --watch --allow-net --allow-read server.js"
+    "start": "deno run --watch --allow-net --allow-read --allow-env --unstable-kv server.js"
   }
 }


### PR DESCRIPTION
## 概要

deno task run で起動できるように起動オプションを追加

## 関連

https://github.com/jigintern/real-2024-b/issues/60

## テスト方法

- deno task start で起動後、確認がでない

## レビュアーチェックリスト

- [ ] 関連にIssueもしくはタスクのリンクがあること
